### PR TITLE
WIP: TwoWayCloser Deprecation

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,0 +1,54 @@
+//go:build !closer_debug
+
+/*
+ * closer - A simple, thread-safe closer
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Roland Singer <roland.singer[at]desertbit.com>
+ * Copyright (c) 2019 Sebastian Borchers <sebastian[at]desertbit.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// Package closer offers a simple, thread-safe closer.
+//
+// It allows to build up a tree of closing relationships, where you typically
+// start with a root closer that branches into different children and
+// children's children. When a parent closer spawns a child closer, the child
+// either has a one-way or two-way connection to its parent. One-way children
+// are closed when their parent closes. In addition, two-way children also close
+// their parent, if they are closed themselves.
+//
+// A closer is also useful to ensure that certain dependencies, such as network
+// connections, are reliably taken down, once the closer closes.
+// In addition, a closer can be concurrently closed many times, without closing
+// more than once, but still returning the errors to every caller.
+//
+// This allows to represent complex closing relationships and helps avoiding
+// leaking goroutines, gracefully shutting down, etc.
+package closer
+
+const (
+	debugEnabled = false
+)
+
+func stacktrace(int) string {
+	return ""
+}

--- a/build_debug.go
+++ b/build_debug.go
@@ -1,0 +1,73 @@
+//go:build closer_debug
+
+/*
+ * closer - A simple, thread-safe closer
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Roland Singer <roland.singer[at]desertbit.com>
+ * Copyright (c) 2019 Sebastian Borchers <sebastian[at]desertbit.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// Package closer offers a simple, thread-safe closer.
+//
+// It allows to build up a tree of closing relationships, where you typically
+// start with a root closer that branches into different children and
+// children's children. When a parent closer spawns a child closer, the child
+// either has a one-way or two-way connection to its parent. One-way children
+// are closed when their parent closes. In addition, two-way children also close
+// their parent, if they are closed themselves.
+//
+// A closer is also useful to ensure that certain dependencies, such as network
+// connections, are reliably taken down, once the closer closes.
+// In addition, a closer can be concurrently closed many times, without closing
+// more than once, but still returning the errors to every caller.
+//
+// This allows to represent complex closing relationships and helps avoiding
+// leaking goroutines, gracefully shutting down, etc.
+package closer
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+const (
+	debugEnabled = true
+)
+
+// Ideas from https://github.com/ztrue/tracerr
+func stacktrace(skip int) string {
+	var b strings.Builder
+	for i := skip; ; i++ {
+		pc, path, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		fn := runtime.FuncForPC(pc)
+		if i != skip {
+			b.WriteString("\n")
+		}
+		b.WriteString(fmt.Sprintf("    %s()\n        %s:%d", fn.Name(), path, line))
+	}
+	return b.String()
+}

--- a/closer.go
+++ b/closer.go
@@ -129,7 +129,7 @@ type Closer interface {
 	// See Close() for the position in the closing order.
 	CloserOneWay() Closer
 
-	// CloserTwoWay is deprecated. Use one closer instance instead.
+	// CloserTwoWay is deprecated. Instead use one closer instance.
 	CloserTwoWay() Closer
 
 	// Context returns a context.Context, which is cancelled


### PR DESCRIPTION
- Rearrange methods
- CloserTwoWay should return itself and print a deprecated warning
- closer_debug build tag for close debugging